### PR TITLE
build: keep only main branch for ci build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,11 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/php-mariadb
 {
 	"name": "PHP & MariaDB",
-	"dockerComposeFile": "docker-compose.yml",
+	"dockerComposeFile": [
+		"docker-compose.yml"
+		// uncomment next line to build image locally
+        // "docker-compose.build.yml"
+    ],
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.devcontainer/docker-compose.build.yml
+++ b/.devcontainer/docker-compose.build.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.8'
 
-services: 
+services:
   app:
     image: ghcr.io/0xffff-one/0xffff-flarum-devcontainer:latest
 
@@ -15,7 +15,7 @@ services:
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
 
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
@@ -31,7 +31,7 @@ services:
 
     # Add "forwardPorts": ["3306"] to **devcontainer.json** to forward MariaDB locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
-  
+
 volumes:
   mariadb-data:
   app-data:

--- a/.github/workflows/devcontainer-release.yml
+++ b/.github/workflows/devcontainer-release.yml
@@ -2,7 +2,7 @@ name: Build Dev Container Image
 
 on:
   push:
-    branches: [ dev-container ]
+    branches: [ main ]
 
 env:
   REGISTRY: ghcr.io
@@ -20,6 +20,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Prepare devcontainer config
+        run: |
+          npm i -g strip-json-comments-cli
+          sudo apt-get install -y jq
+          strip-json-comments .devcontainer/devcontainer.json | jq '.dockerComposeFile[1]="docker-compose.build.yml"' > .devcontainer/devcontainer.json
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9


### PR DESCRIPTION
1. Since neither the `devcontainers/ci` action doesn't support specifing a different config path, nor the config can't specify a different `dockerComposeFile` value via environment, we have to proactively adjust the compose config to build from local `Dockerfile`.
2. It's quite hard to modify `devcontainer.json` using shell commands, as it's in jsonc format, we need some triky.
3. Fortunately, we can first strip the comments from that json file using an npm package, and then modify it using the jq tool. These tools help us to make things simpler and more manageable.

Not tested. It may works or not, just depends on if all the github action step can run and finish correctly :-)

Solve #44.