### PR TITLE
build: auto composer install deps after the container is created

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,16 +27,17 @@ RUN yes | pecl install xdebug \
     && echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 RUN \
-    # composer
-    curl -sS https://getcomposer.org/installer | php \
-    && mv composer.phar /usr/local/bin/composer \
     # nginx
-    && addgroup --system --gid 123 nginx \
+    addgroup --system --gid 123 nginx \
     && adduser --system --disabled-login --ingroup nginx --no-create-home --gecos "nginx user" --shell /bin/false --uid 123 nginx \
     && mkdir -p /data/log/nginx \
     && chown -R nginx:nginx /data/log/nginx \
     # clean
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# multiple-stage builds, see https://docs.docker.com/develop/develop-images/multistage-build/
+# currently we don't want to bundle the deps in image, so just copy the compiled executable only.
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 # nginx config
 ADD ./nginx/nginx.conf /etc/nginx/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,10 +48,11 @@
 		8080,
 		3306
 	],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
 	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// Restrict deps installation to first initialization, in which case the verdor directory doesn't exist locally
+	"postCreateCommand": "[ ! -d vendor ] && composer install",
 	// Use 'postStartCommand' to run commands each time the container is successfully started.
 	"postStartCommand": "start"
 }


### PR DESCRIPTION
- To make the start-up procedure simpler and more foolproof. The `postCreateCommand` will only be ran once after the container is built or re-built, and will not be ran after you start or reconnect the container. So we can gracefully place the `composer install` at this entry to ensure every newcomer or new container is ready to use out of the box.
- And we can save a little build time by copying the composer executable from the official image. But since we don't want to bundle the vendor directory into the app image(or may be improved next time), we actually do not need multiple- stage build and just leave it for scalable.
- But even so, you still need to execute `compose update` when you need to update deps locally. This is feasible for advanced developers, as they want to care about the flarum extensions, the php library, and so on.