### PR TITLE
feat: use devcontainer features

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-bullseye
+FROM php:8.2-fpm-bookworm
 
 # Change to USTC mirror to accelerate the building process
 RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list && \
@@ -7,7 +7,6 @@ RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list && \
 # Install MariaDB client and dependencies
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y mariadb-client libpng-dev libjpeg-dev libfreetype6-dev libgmp-dev redis nginx
-    # && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 RUN \
     # php extensions
@@ -61,21 +60,3 @@ RUN chmod 0755 /bin/start-nginx \
     && chmod 0755 /bin/start-app \
     && chmod 0755 /bin/start \
     && chmod -R 0755 /etc/redis
-
-# Node.js env setup
-# ref: https://nodejs.org/en/download/package-manager#debian-and-ubuntu-based-linux-distributions
-#   -> https://github.com/nodesource/distributions
-
-RUN \
-    apt-get update; \
-    apt-get install -y ca-certificates curl gnupg; \
-    mkdir -p /etc/apt/keyrings; \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
-    # set env
-    NODE_MAJOR=18; \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
-    # install
-    apt-get update; \
-    apt-get install nodejs yarn -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"dockerComposeFile": [
 		"docker-compose.yml"
 		// uncomment next line to build image locally
-        // "docker-compose.build.yml"
+		// "docker-compose.build.yml"
     ],
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
@@ -18,6 +18,12 @@
 			"userUid": "1000",
 			"userGid": "1000",
 			"upgradePackages": "true"
+		},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"moby": false
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "lts"
 		}
 	},
 	// from: https://github.com/devcontainers/images/blob/4ea2ed96dc80d4baebd0eef1efceeb27e33a3aef/src/php/.devcontainer/devcontainer.json


### PR DESCRIPTION
1. add `docker-outside-of-docker` feature to make vscode docker extension available while developing inside the devcontainer.
2. add `node` feature to automatically install latest node, nvm, npm, yarn, pnpm etc.
3. upgrade base image from debian 11 to 12 for devcontainer.